### PR TITLE
ci: pin actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"
-    open-pull-requests-limit: 1

--- a/.github/workflows/BuildArtifacts.yml
+++ b/.github/workflows/BuildArtifacts.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: julia-actions/setup-julia@v3
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: "1"
 
@@ -30,14 +30,14 @@ jobs:
       - run: git status
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           title: "Update bun artifacts"
           body: "This is an automated pull request to update the bun artifacts."
           commit-message: "This is an automated pull request to update the bun artifacts."
 
       - name: Create Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: "build/artifacts/*.tar.gz"
           tag: ${{ steps.build.outputs.bun_version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,15 +53,15 @@ jobs:
             os: macOS-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: julia-actions/install-juliaup@v3
+      - uses: julia-actions/install-juliaup@05d98a2ef433ca0723a8221e38c4723ea92b0c5f # v3.1.4
         with:
           channel: "${{ matrix.version }}"
 
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
 
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
 
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1.11.4
         continue-on-error: ${{ matrix.version == 'nightly' }}

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -15,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v3
+        uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1'
           arch: ${{ runner.arch }}

--- a/.github/workflows/LicenseUpdater.yml
+++ b/.github/workflows/LicenseUpdater.yml
@@ -9,9 +9,9 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v3
+      - uses: FantasticFiasco/action-update-license-year@f180e962fa988db222d8f03ef4636750312d1b3d # v3.0.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Register.yml
+++ b/.github/workflows/Register.yml
@@ -11,6 +11,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: julia-actions/RegisterAction@latest
+      - uses: julia-actions/RegisterAction@d391a7f14ee6db8ad3f8cd26f6da1a6c6fd5b7fb # v0.3.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -25,6 +25,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1.25.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Floating tags like v6 move silently, changing what CI runs without a diff.
Pin every action to its commit SHA with a version comment so the runner is
reproducible.

Give dependabot a 7-day cooldown and group all github-actions updates into
one PR, so the pins stay maintainable without an update flood.
